### PR TITLE
disabled dark mode

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -8,13 +8,14 @@
   --background-end-rgb: 255, 255, 255;
 }
 
-@media (prefers-color-scheme: dark) {
+/*@media (prefers-color-scheme: dark) {
   :root {
     --foreground-rgb: 255, 255, 255;
     --background-start-rgb: 0, 0, 0;
     --background-end-rgb: 0, 0, 0;
   }
 }
+*/
 
 body {
   color: rgb(var(--foreground-rgb));


### PR DESCRIPTION
Dark mode styles were not being handled consistently, so it has been disabled until it is properly implemented.

For example, the login page on dark mode was displaying white text which was being inherited from the global css styles for dark mode, which was not visible on the white background of the input. This issue is likely to persisted elsewhere until the styles for dark mode are more consistently nailed down to prevent this type of issue.